### PR TITLE
Add loading spinner

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "react": "^16.13.1",
         "react-dom": "^16.13.1",
         "react-scripts": "^4.0.3",
+        "react-spinners": "^0.13.4",
         "use-places-autocomplete": "^1.5.9",
         "whatwg-fetch": "^3.0.0"
       },
@@ -18652,6 +18653,15 @@
       "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-spinners": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/react-spinners/-/react-spinners-0.13.4.tgz",
+      "integrity": "sha512-V6IURjYOwomhdngMfuVxBp4utCF6v21sjQ6r4K2JoKl8fwXZp1UeHMBLf+2SU+cts8hAVj9rHOJ8kdT5UqqaJw==",
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-transition-group": {
@@ -38283,6 +38293,12 @@
           "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ=="
         }
       }
+    },
+    "react-spinners": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/react-spinners/-/react-spinners-0.13.4.tgz",
+      "integrity": "sha512-V6IURjYOwomhdngMfuVxBp4utCF6v21sjQ6r4K2JoKl8fwXZp1UeHMBLf+2SU+cts8hAVj9rHOJ8kdT5UqqaJw==",
+      "requires": {}
     },
     "react-transition-group": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-scripts": "^4.0.3",
+    "react-spinners": "^0.13.4",
     "use-places-autocomplete": "^1.5.9",
     "whatwg-fetch": "^3.0.0"
   },

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -20,8 +20,16 @@ function App() {
   return (
     <div className="App">
       <h1>ravenous</h1>
-      <SearchBar yelpBusinesses={yelpBusinesses} hasRun={hasRun} isLoading={isLoading} setIsLoading={setIsLoading} />
-      <BusinessList businesses={businesses} hasRun={hasRun} />
+      <SearchBar
+        yelpBusinesses={yelpBusinesses}
+        hasRun={hasRun}
+        isLoading={isLoading}
+        setIsLoading={setIsLoading}
+      />
+      <BusinessList
+        businesses={businesses}
+        hasRun={hasRun}
+      />
     </div>
   );
 }

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -8,9 +8,12 @@ import searchYelp from '../../util/searchYelp.js';
 function App() {
   const [businesses, setBusinesses] = useState([]);
   const [hasRun, setHasRun] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
 
   async function yelpBusinesses(term, location, priceString, sortBy) {
+    setIsLoading(true);
     const response = await searchYelp(term, location, priceString, sortBy);
+    setIsLoading(false);
     setBusinesses(response);
     setHasRun(true);
   }

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -11,7 +11,6 @@ function App() {
   const [isLoading, setIsLoading] = useState(false);
 
   async function yelpBusinesses(term, location, priceString, sortBy) {
-    setIsLoading(true);
     const response = await searchYelp(term, location, priceString, sortBy);
     setIsLoading(false);
     setBusinesses(response);
@@ -21,7 +20,7 @@ function App() {
   return (
     <div className="App">
       <h1>ravenous</h1>
-      <SearchBar yelpBusinesses={yelpBusinesses} hasRun={hasRun} isLoading={isLoading} />
+      <SearchBar yelpBusinesses={yelpBusinesses} hasRun={hasRun} isLoading={isLoading} setIsLoading={setIsLoading} />
       <BusinessList businesses={businesses} hasRun={hasRun} />
     </div>
   );

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -21,8 +21,8 @@ function App() {
   return (
     <div className="App">
       <h1>ravenous</h1>
-      <SearchBar yelpBusinesses={yelpBusinesses} hasRun={hasRun}/>
-      <BusinessList businesses={businesses} hasRun={hasRun}/>
+      <SearchBar yelpBusinesses={yelpBusinesses} hasRun={hasRun} isLoading={isLoading} />
+      <BusinessList businesses={businesses} hasRun={hasRun} />
     </div>
   );
 }

--- a/src/components/SearchBar/SearchBar.css
+++ b/src/components/SearchBar/SearchBar.css
@@ -59,6 +59,7 @@
 
 .SearchBar-submit {
   text-align: center;
+  position: relative;
 }
 
 .SearchBar-submit button {

--- a/src/components/SearchBar/SearchBar.css
+++ b/src/components/SearchBar/SearchBar.css
@@ -78,6 +78,14 @@
   background-color: #a7874b;
 }
 
+.active {
+  opacity: 1;
+}
+
+.inactive {
+  opacity: 0.1;
+}
+
 #term, #location {
   margin: 10px;
   height: 17px;

--- a/src/components/SearchBar/SearchBar.css
+++ b/src/components/SearchBar/SearchBar.css
@@ -83,7 +83,7 @@
 }
 
 .inactive {
-  opacity: 0.1;
+  opacity: 0.4;
 }
 
 #term, #location {

--- a/src/components/SearchBar/SearchBar.js
+++ b/src/components/SearchBar/SearchBar.js
@@ -107,7 +107,7 @@ function SearchBar(props) {
   }, [sortBy]);
 
   useEffect(() => {
-    if (enterKey) handleSearchKey();
+    if (enterKey && !isLoading) handleSearchKey();
   });
 
   return (

--- a/src/components/SearchBar/SearchBar.js
+++ b/src/components/SearchBar/SearchBar.js
@@ -107,6 +107,10 @@ function SearchBar(props) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sortBy]);
 
+  useEffect(() => {
+    if (enterKey) handleSearchKey();
+  });
+
   return (
     <div className="SearchBar">
       <div className="SearchBar-sort-options">
@@ -140,7 +144,6 @@ function SearchBar(props) {
         >
           Let's Go
         </button>
-        {enterKey && handleSearchKey()}
       </div>
     </div>
   );

--- a/src/components/SearchBar/SearchBar.js
+++ b/src/components/SearchBar/SearchBar.js
@@ -128,7 +128,7 @@ function SearchBar(props) {
       </div>
       <div className="SearchBar-submit">
         <PulseLoader loading={props.isLoading} color="#48ad6b" cssOverride={override} />
-        <button onClick={handleSearch} disabled={props.isLoading}>Let's Go</button>
+        <button className={props.isLoading ? "inactive" : "active"} onClick={handleSearch} disabled={props.isLoading}>Let's Go</button>
         {enterKey && handleSearchKey()}
       </div>
     </div>

--- a/src/components/SearchBar/SearchBar.js
+++ b/src/components/SearchBar/SearchBar.js
@@ -11,6 +11,13 @@ const sortByOptions = {
   'Most Reviewed': 'review_count'
 };
 
+const override = {
+  position: "absolute",
+  margin: "auto",
+  width: "100%",
+  padding: ".5rem 0rem",
+};
+
 
 function SearchBar(props) {
   const [term, setTerm] = useState('');
@@ -120,7 +127,7 @@ function SearchBar(props) {
           onChange={handleLocationChange} />
       </div>
       <div className="SearchBar-submit">
-        <PulseLoader loading={true} color="#48ad6b" />
+        <PulseLoader loading={true} color="#48ad6b" cssOverride={override} />
         <button onClick={handleSearch}>Let's Go</button>
         {enterKey && handleSearchKey()}
       </div>

--- a/src/components/SearchBar/SearchBar.js
+++ b/src/components/SearchBar/SearchBar.js
@@ -27,7 +27,7 @@ function SearchBar(props) {
 
   const priceString = priceQuery(price);
   const enterKey = useKeyPress('Enter');
-  const { yelpBusinesses, isLoading, hasRun } = props;
+  const { yelpBusinesses, hasRun, isLoading, setIsLoading } = props;
 
   function getSortByClass(sortByOption) {
     return ((sortBy === sortByOption) ? 'active' : '');
@@ -59,10 +59,11 @@ function SearchBar(props) {
 
   const handleSearch = useCallback( (e) => {
     if (checkInputs(term, location)) {
+      setIsLoading(true);
       yelpBusinesses(term, location, priceString, sortBy);
     }
     e && e.preventDefault();
-  }, [yelpBusinesses, term, location, priceString, sortBy]);
+  }, [setIsLoading, yelpBusinesses, term, location, priceString, sortBy]);
 
   function handleSearchKey() {
     if (checkInputs(term, location)) {

--- a/src/components/SearchBar/SearchBar.js
+++ b/src/components/SearchBar/SearchBar.js
@@ -127,7 +127,7 @@ function SearchBar(props) {
           onChange={handleLocationChange} />
       </div>
       <div className="SearchBar-submit">
-        <PulseLoader loading={true} color="#48ad6b" cssOverride={override} />
+        <PulseLoader loading={props.isLoading} color="#48ad6b" cssOverride={override} />
         <button onClick={handleSearch}>Let's Go</button>
         {enterKey && handleSearchKey()}
       </div>

--- a/src/components/SearchBar/SearchBar.js
+++ b/src/components/SearchBar/SearchBar.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
+import PulseLoader from "react-spinners/PulseLoader";
 import PlacesAutocomplete from '../PlacesAutocomplete/PlacesAutocomplete.js';
 import PriceSlider from '../PriceSlider/PriceSlider.js';
 import useKeyPress from '../../util/useKeyPress.js';
@@ -119,6 +120,7 @@ function SearchBar(props) {
           onChange={handleLocationChange} />
       </div>
       <div className="SearchBar-submit">
+        <PulseLoader loading={true} color="#48ad6b" />
         <button onClick={handleSearch}>Let's Go</button>
         {enterKey && handleSearchKey()}
       </div>

--- a/src/components/SearchBar/SearchBar.js
+++ b/src/components/SearchBar/SearchBar.js
@@ -128,7 +128,7 @@ function SearchBar(props) {
       </div>
       <div className="SearchBar-submit">
         <PulseLoader loading={props.isLoading} color="#48ad6b" cssOverride={override} />
-        <button onClick={handleSearch}>Let's Go</button>
+        <button onClick={handleSearch} disabled={props.isLoading}>Let's Go</button>
         {enterKey && handleSearchKey()}
       </div>
     </div>

--- a/src/components/SearchBar/SearchBar.js
+++ b/src/components/SearchBar/SearchBar.js
@@ -128,8 +128,18 @@ function SearchBar(props) {
           onChange={handleLocationChange} />
       </div>
       <div className="SearchBar-submit">
-        <PulseLoader loading={isLoading} color="#48ad6b" cssOverride={override} />
-        <button className={isLoading ? "inactive" : "active"} onClick={handleSearch} disabled={isLoading}>Let's Go</button>
+        <PulseLoader
+          loading={isLoading}
+          color="#48ad6b"
+          cssOverride={override}
+        />
+        <button
+          className={isLoading ? "inactive" : "active"}
+          onClick={handleSearch}
+          disabled={isLoading}
+        >
+          Let's Go
+        </button>
         {enterKey && handleSearchKey()}
       </div>
     </div>

--- a/src/components/SearchBar/SearchBar.js
+++ b/src/components/SearchBar/SearchBar.js
@@ -102,9 +102,7 @@ function SearchBar(props) {
   }
 
   useEffect(() => {
-    if (hasRun) {
-      handleSearch();
-    }
+    if (hasRun) handleSearch();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sortBy]);
 

--- a/src/components/SearchBar/SearchBar.js
+++ b/src/components/SearchBar/SearchBar.js
@@ -27,7 +27,7 @@ function SearchBar(props) {
 
   const priceString = priceQuery(price);
   const enterKey = useKeyPress('Enter');
-  const { yelpBusinesses } = props;
+  const { yelpBusinesses, isLoading, hasRun } = props;
 
   function getSortByClass(sortByOption) {
     return ((sortBy === sortByOption) ? 'active' : '');
@@ -66,7 +66,7 @@ function SearchBar(props) {
 
   function handleSearchKey() {
     if (checkInputs(term, location)) {
-      props.yelpBusinesses(term, location, priceString, sortBy);
+      yelpBusinesses(term, location, priceString, sortBy);
     }
   }
 
@@ -100,7 +100,7 @@ function SearchBar(props) {
   }
 
   useEffect(() => {
-    if (props.hasRun) {
+    if (hasRun) {
       handleSearch();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -127,8 +127,8 @@ function SearchBar(props) {
           onChange={handleLocationChange} />
       </div>
       <div className="SearchBar-submit">
-        <PulseLoader loading={props.isLoading} color="#48ad6b" cssOverride={override} />
-        <button className={props.isLoading ? "inactive" : "active"} onClick={handleSearch} disabled={props.isLoading}>Let's Go</button>
+        <PulseLoader loading={isLoading} color="#48ad6b" cssOverride={override} />
+        <button className={isLoading ? "inactive" : "active"} onClick={handleSearch} disabled={isLoading}>Let's Go</button>
         {enterKey && handleSearchKey()}
       </div>
     </div>

--- a/src/components/SearchBar/SearchBar.js
+++ b/src/components/SearchBar/SearchBar.js
@@ -67,6 +67,7 @@ function SearchBar(props) {
 
   function handleSearchKey() {
     if (checkInputs(term, location)) {
+      setIsLoading(true);
       yelpBusinesses(term, location, priceString, sortBy);
     }
   }


### PR DESCRIPTION
Built a spinner feature using the `react-spinners` package. This displays a loading animation over the `submit` button when a call to the Yelp API is being made. Implemented for both when the `submit` button is clicked and when `enter` is pressed.

Also prevented multiple API calls being stacked via pressing the `submit` button or `enter` multiple times whilst the first API call was underway. The button's `opacity` gets reduced when a call is being made to give a visible cue that it has been disabled.

All bugs and warnings were resolved as part of this feature completion.